### PR TITLE
chore: ignore docs directory for CG

### DIFF
--- a/build/update-wasm.yml
+++ b/build/update-wasm.yml
@@ -34,7 +34,7 @@ extends:
 
           - script: echo '##vso[task.prependpath]/opt/dev/emsdk/upstream/emscripten'
             displayName: Setup emsdk path 1
-            
+
           - script: echo '##vso[task.prependpath]/opt/dev/emsdk'
             displayName: Setup emsdk path 2
 
@@ -44,5 +44,6 @@ extends:
           - script: npm run build-wasm
             displayName: Build all wasm
 
+        cgIgnoreDirectories: $(Build.SourcesDirectory)/tree-sitter/docs
         publishPackage: ${{ parameters.publishPackage }}
         skipAPIScan: true # Package does not build on Windows


### PR DESCRIPTION
I confirmed that we don't re-publish tree-sitter's docs. This PR allows CG to ignore that docs folder so that we don't get CG alerts for Ruby dependencies that we don't re-publish.
Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=296166&view=results