### PR TITLE
chore: declare Rust target

### DIFF
--- a/build/update-wasm.yml
+++ b/build/update-wasm.yml
@@ -27,6 +27,7 @@ extends:
   parameters:
     npmPackages:
       - name: tree-sitter-wasm
+        rustTargets: x86_64-unknown-linux-gnu
 
         buildSteps:
           - script: ./build/setup-emsdk.sh


### PR DESCRIPTION
Fixes the build, which broke due to new network isolation requirements, by allowing the pipeline to set up its Rust install.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=461442&view=results